### PR TITLE
Latency (and other) updates

### DIFF
--- a/trafficgen.lua
+++ b/trafficgen.lua
@@ -1013,10 +1013,8 @@ function timerSlave(runTime, testParams, queueIds)
 		end
 	end
 	moongen.sleepMillis(LATENCY_TRIM + 1000) -- the extra 1000 ms ensures the stats are output after the throughput stats
-	local histDesc = "Histogram port " .. ("%d"):format(queueIds[1].id) .. " to port " .. ("%d"):format(queueIds[2].id)
-	local histFile = "hist:" .. ("%d"):format(queueIds[1].id) .. "-" .. ("%d"):format(queueIds[2].id) .. ".csv"
-	--local histDesc = "Histogram port " .. testParams.ports[queueIds[1].id] .. " to port " .. testParams.ports[queueIds[2].id]
-	--local histFile = "hist:" .. testParams.ports[queueIds[1].id] .. "-" .. testParams.ports[queueIds[2].id] .. ".csv"
+	local histDesc = "Histogram port " .. ("%d"):format(queueIds[1].id) .. " to port " .. ("%d"):format(queueIds[2].id) .. " at rate " .. testParams.rate .. " Mpps"
+	local histFile = "hist:" .. ("%d"):format(queueIds[1].id) .. "-" .. ("%d"):format(queueIds[2].id) .. "_rate:" .. testParams.rate .. ".csv"
 	if haveHisto1 then
 		hist1:print(histDesc)
 		hist1:save(histFile)
@@ -1028,8 +1026,8 @@ function timerSlave(runTime, testParams, queueIds)
 		log:warn("no latency samples found for %s", histDesc)
 	end
 	if testParams.runBidirec then
-		local histDesc = "Histogram port " .. ("%d"):format(queueIds[3].id) .. " to port " .. ("%d"):format(queueIds[4].id)
-		local histFile = "hist:" .. ("%d"):format(queueIds[3].id) .. "-" .. ("%d"):format(queueIds[4].id) .. ".csv"
+		local histDesc = "Histogram port " .. ("%d"):format(queueIds[3].id) .. " to port " .. ("%d"):format(queueIds[4].id) .. " at rate " .. testParams.rate .. " Mpps"
+		local histFile = "hist:" .. ("%d"):format(queueIds[3].id) .. "-" .. ("%d"):format(queueIds[4].id) .. "_rate:" .. testParams.rate .. ".csv"
 		if haveHisto2 then
 			hist2:print(histDesc)
 			hist2:save(histFile)

--- a/trafficgen.lua
+++ b/trafficgen.lua
@@ -34,6 +34,7 @@
 -- txQueuesPerDev	Integer: The number of queues to use when transmitting packets.  The default is 3 and should not need to be changed
 -- frameSize		Integer: the size of the Ethernet frame (including CRC)
 -- oneShot		true or false: set to true only if you don't want a binary search for maximum packet rate
+-- negativeLossRetry	true or false: set to false only if you want to allow negative packet loss attempts to pass
 
 local moongen	= require "moongen"
 local dpdk	= require "dpdk"
@@ -366,6 +367,7 @@ function getTestParams(testParams)
 	testParams.srcIp = parseIPAddress(testParams.srcIp)
 	testParams.dstIp = parseIPAddress(testParams.dstIp)
 	testParams.oneShot = testParams.oneShot or false
+	testParams.negativeLossRetry = testParams.negativeLossRetry and true
 	testParams.mppsPerQueue = testParams.mppsPerQueue or MPPS_PER_QUEUE
 	testParams.queuesPerTask = testParams.queuesPerTask or QUEUES_PER_TASK
 	testParams.rxQueuesPerDev = 1
@@ -396,7 +398,7 @@ function acceptableLoss(testParams, rxStats, txStats, maxNegativeLossAttempts, t
 				 		testParams.ports[i], testParams.ports[testParams.connections[i]], lostFrames, lostFramePct, testParams.acceptableLossPct);
 						pass = ATTEMPT_FAIL
 					else
-						if (lostFramePct < 0) then
+						if testParams.negativeLossRetry and lostFramePct < 0 then
 							if pass == ATTEMPT_PASS then
 								pass = ATTEMPT_RETRY
 							end

--- a/trafficgen.lua
+++ b/trafficgen.lua
@@ -107,6 +107,7 @@ end
 
 function master(...)
 	local testParams = getTestParams()
+	dumpTestParams(testParams)
 	local finalValidation = false
 	local prevRate = 0
 	local prevPassRate = 0
@@ -811,6 +812,30 @@ function dumpQueues(queueIds)
 		queues = queues..queueId:__tostring()
 	end
 	return queues
+end
+
+function dumpTable(table, indent)
+	local indentString = ""
+
+	for i=1,indent,1 do
+		indentString = indentString.."\t"
+	end
+
+	for key,value in pairs(table) do
+		if type(value) == "table" then
+			log:info("%s%s => {", indentString, key)
+			dumpTable(value, indent+1)
+			log:info("%s}", indentString)
+		else
+			log:info("%s%s: %s", indentString, key, value)
+		end
+	end
+end
+
+function dumpTestParams(testParams)
+	log:info("testParams => {")
+	dumpTable(testParams, 1)
+	log:info("}")
 end
 
 function calibrateSlave(devs, devId, calibratedRate, testParams, taskId, queueIds)

--- a/trafficgen.lua
+++ b/trafficgen.lua
@@ -131,7 +131,7 @@ function master(...)
 	if testParams.testType == "latency" then 
 		printf("Starting latency test", testParams.acceptableLossPct);
 		if launchTest(finalValidation, devs, testParams, txStats, rxStats) then
-			showReport(rxStats, txStats, testParams)
+			showReport(rxStats, txStats, testParams, "REPORT")
 		else
 			log:error("Test failed");
 			return
@@ -155,9 +155,10 @@ function master(...)
 						prevRate = testParams.rate
 						if testParams.oneShot or (acceptableLossResult == ATTEMPT_PASS) then
 							if finalValidation then
-								showReport(rxStats, txStats, testParams)
+								showReport(rxStats, txStats, testParams, "REPORT")
 								return
 							else
+								showReport(rxStats, txStats, testParams, "RESULT")
 								nextRate = (prevFailRate + testParams.rate ) / 2
 								if math.abs(nextRate - testParams.rate) <= testParams.rate_granularity then
 									-- since the rate difference from rate that just passed and the next rate is not greater than rate_granularity, the next run is a "final validation"
@@ -168,6 +169,7 @@ function master(...)
 								end
 							end
 						else
+							showReport(rxStats, txStats, testParams, "RESULT")
 							if testParams.rate <= testParams.rate_granularity then
 								log:error("Could not even pass with rate <= the rate granularity, %f", testParams.rate_granularity)
 								return
@@ -202,7 +204,7 @@ function master(...)
 	end
 end
 
-function showReport(rxStats, txStats, testParams)
+function showReport(rxStats, txStats, testParams, mode)
 	local totalRxMpps = 0
 	local totalTxMpps = 0
 	local totalRxFrames = 0
@@ -242,13 +244,13 @@ function showReport(rxStats, txStats, testParams)
 			totalTxFrames = totalTxFrames + txStats[i].totalFrames
 			totalLostFrames = totalLostFrames + lostFrames
 			totalLostFramePct = 100 * totalLostFrames / totalTxFrames
-			printf("[REPORT]Device %d->%d: Tx frames: %d Rx Frames: %d frame loss: %d, %f%% Rx Mpps: %f",
+			printf("[%s]Device %d->%d: Tx frames: %d Rx Frames: %d frame loss: %d, %f%% Rx Mpps: %f", mode,
 			 testParams.ports[i], testParams.ports[testParams.connections[i]], txStats[i].totalFrames,
 			 rxStats[testParams.connections[i]].totalFrames, lostFrames, lostFramePct, rxMpps)
 		end
 	end
-	printf("[REPORT]      total: Tx frames: %d Rx Frames: %d frame loss: %d, %f%% Tx Mpps: %f Rx Mpps: %f",
-	 totalTxFrames, totalRxFrames, totalLostFrames, totalLostFramePct, totalTxMpps, totalRxMpps)
+	printf("[%s]      total: Tx frames: %d Rx Frames: %d frame loss: %d, %f%% Tx Mpps: %f Rx Mpps: %f",
+	 mode, totalTxFrames, totalRxFrames, totalLostFrames, totalLostFramePct, totalTxMpps, totalRxMpps)
 end
 
 function prepareDevs(testParams)

--- a/trafficgen.lua
+++ b/trafficgen.lua
@@ -967,6 +967,12 @@ function timerSlave(runTime, testParams, queueIds)
 	local sampleLog2 = {}
 
 	-- TODO: adjust headers for flows
+
+	if testParams.runBidirec then
+		log:info("timerSlave: bidirectional testing from %d->%d and %d->%d", queueIds[1].id, queueIds[2].id, queueIds[3].id, queueIds[4].id)
+	else
+		log:info("timerSlave: unidirectional testing from %d->%d", queueIds[1].id, queueIds[2].id)
+	end
 	
 	hist1 = hist()
 	timestamper1 = ts:newUdpTimestamper(queueIds[1], queueIds[2])

--- a/trafficgen.lua
+++ b/trafficgen.lua
@@ -986,6 +986,13 @@ function saveSampleLog(file, samples, label)
 	file:close()
 end
 
+function saveHistogram(file, hist, label)
+	output = io.open(file, "w")
+	output:write("bucket,", label, "\n")
+	hist:save(output)
+	output:close()
+end
+
 function timerSlave(runTime, testParams, queueIds)
 	local hist1, hist2, haveHisto1, haveHisto2, timestamper1, timestamper2
 	local transactionsPerDirection = 1 -- the number of transactions before switching direction
@@ -1075,30 +1082,30 @@ function timerSlave(runTime, testParams, queueIds)
 	moongen.sleepMillis(LATENCY_TRIM + 1000) -- the extra 1000 ms ensures the stats are output after the throughput stats
 	local histDesc = "Histogram port " .. ("%d"):format(queueIds[1].id) .. " to port " .. ("%d"):format(queueIds[2].id) .. " at rate " .. testParams.rate .. " Mpps"
 	local histFile = "dev:" .. ("%d"):format(queueIds[1].id) .. "-" .. ("%d"):format(queueIds[2].id) .. "_rate:" .. testParams.rate .. ".csv"
-	local sampleLabel = "Dev:" .. ("%d"):format(queueIds[1].id) .. "->" .. ("%d"):format(queueIds[2].id) .. " @ " .. testParams.rate .. " Mpps"
+	local headerLabel = "Dev:" .. ("%d"):format(queueIds[1].id) .. "->" .. ("%d"):format(queueIds[2].id) .. " @ " .. testParams.rate .. " Mpps"
 	if haveHisto1 then
 		hist1:print(histDesc)
-		hist1:save("latency:histogram_" .. histFile)
+		saveHistogram("latency:histogram_" .. histFile, hist1, headerLabel)
 		local hist_size = hist1:totals()
 		if hist_size ~= counter1 then
 		   log:warn("[%s] Lost %d samples (%.2f%%)!", histDesc, counter1 - hist_size, (counter1 - hist_size)/counter1*100)
 		end
-		saveSampleLog("latency:samples_" .. histFile, sampleLog1, sampleLabel)
+		saveSampleLog("latency:samples_" .. histFile, sampleLog1, headerLabel)
 	else
 		log:warn("no latency samples found for %s", histDesc)
 	end
 	if testParams.runBidirec then
 		local histDesc = "Histogram port " .. ("%d"):format(queueIds[3].id) .. " to port " .. ("%d"):format(queueIds[4].id) .. " at rate " .. testParams.rate .. " Mpps"
 		local histFile = "dev:" .. ("%d"):format(queueIds[3].id) .. "-" .. ("%d"):format(queueIds[4].id) .. "_rate:" .. testParams.rate .. ".csv"
-		local sampleLabel = "Dev:" .. ("%d"):format(queueIds[3].id) .. "->" .. ("%d"):format(queueIds[4].id) .. " @ " .. testParams.rate .. " Mpps"
+		local headerLabel = "Dev:" .. ("%d"):format(queueIds[3].id) .. "->" .. ("%d"):format(queueIds[4].id) .. " @ " .. testParams.rate .. " Mpps"
 		if haveHisto2 then
 			hist2:print(histDesc)
-			hist2:save("latency:histogram_" .. histFile)
+			saveHistogram("latency:histogram_" .. histFile, hist2, headerLabel)
 			local hist_size = hist2:totals()
 			if hist_size ~= counter2 then
 			   log:warn("[%s] Lost %d samples (%.2f%%)!", histDesc, counter2 - hist_size, (counter2 - hist_size)/counter2*100) 
 			end
-			saveSampleLog("latency:samples_" .. histFile, sampleLog2, sampleLabel)
+			saveSampleLog("latency:samples_" .. histFile, sampleLog2, headerLabel)
 		else
 			log:warn("no latency samples found for %s", histDesc)
 		end

--- a/trafficgen.lua
+++ b/trafficgen.lua
@@ -976,9 +976,10 @@ function loadSlave(devs, devId, calibratedRate, runTime, testParams, taskId, que
         return results
 end
 
-function saveSampleLog(file, samples)
+function saveSampleLog(file, samples, label)
 	log:info("Saving sample log to '%s'", file)
 	file = io.open(file, "w+")
+	file:write("samples,", label, "\n")
 	for i,v in ipairs(samples) do
 		file:write(i, ",", v, "\n")
 	end
@@ -1074,6 +1075,7 @@ function timerSlave(runTime, testParams, queueIds)
 	moongen.sleepMillis(LATENCY_TRIM + 1000) -- the extra 1000 ms ensures the stats are output after the throughput stats
 	local histDesc = "Histogram port " .. ("%d"):format(queueIds[1].id) .. " to port " .. ("%d"):format(queueIds[2].id) .. " at rate " .. testParams.rate .. " Mpps"
 	local histFile = "dev:" .. ("%d"):format(queueIds[1].id) .. "-" .. ("%d"):format(queueIds[2].id) .. "_rate:" .. testParams.rate .. ".csv"
+	local sampleLabel = "Dev:" .. ("%d"):format(queueIds[1].id) .. "->" .. ("%d"):format(queueIds[2].id) .. " @ " .. testParams.rate .. " Mpps"
 	if haveHisto1 then
 		hist1:print(histDesc)
 		hist1:save("latency:histogram_" .. histFile)
@@ -1081,13 +1083,14 @@ function timerSlave(runTime, testParams, queueIds)
 		if hist_size ~= counter1 then
 		   log:warn("[%s] Lost %d samples (%.2f%%)!", histDesc, counter1 - hist_size, (counter1 - hist_size)/counter1*100)
 		end
-		saveSampleLog("latency:samples_" .. histFile, sampleLog1)
+		saveSampleLog("latency:samples_" .. histFile, sampleLog1, sampleLabel)
 	else
 		log:warn("no latency samples found for %s", histDesc)
 	end
 	if testParams.runBidirec then
 		local histDesc = "Histogram port " .. ("%d"):format(queueIds[3].id) .. " to port " .. ("%d"):format(queueIds[4].id) .. " at rate " .. testParams.rate .. " Mpps"
 		local histFile = "dev:" .. ("%d"):format(queueIds[3].id) .. "-" .. ("%d"):format(queueIds[4].id) .. "_rate:" .. testParams.rate .. ".csv"
+		local sampleLabel = "Dev:" .. ("%d"):format(queueIds[3].id) .. "->" .. ("%d"):format(queueIds[4].id) .. " @ " .. testParams.rate .. " Mpps"
 		if haveHisto2 then
 			hist2:print(histDesc)
 			hist2:save("latency:histogram_" .. histFile)
@@ -1095,7 +1098,7 @@ function timerSlave(runTime, testParams, queueIds)
 			if hist_size ~= counter2 then
 			   log:warn("[%s] Lost %d samples (%.2f%%)!", histDesc, counter2 - hist_size, (counter2 - hist_size)/counter2*100) 
 			end
-			saveSampleLog("latency:samples_" .. histFile, sampleLog2)
+			saveSampleLog("latency:samples_" .. histFile, sampleLog2, sampleLabel)
 		else
 			log:warn("no latency samples found for %s", histDesc)
 		end

--- a/trafficgen.lua
+++ b/trafficgen.lua
@@ -975,9 +975,18 @@ function timerSlave(runTime, testParams, queueIds)
 	end
 	
 	hist1 = hist()
-	timestamper1 = ts:newUdpTimestamper(queueIds[1], queueIds[2])
+	if testParams.frameSize < 76 then
+		log:warn("Latency packets are not UDP due to requested size (%d) less than minimum UDP size (76)", testParams.frameSize)
+		timestamper1 = ts:newTimestamper(queueIds[1], queueIds[2])
+	else
+		timestamper1 = ts:newUdpTimestamper(queueIds[1], queueIds[2])
+	end
 	if testParams.runBidirec then
-		timestamper2 = ts:newUdpTimestamper(queueIds[3], queueIds[4])
+		if testParams.frameSize < 76 then
+			timestamper2 = ts:newTimestamper(queueIds[3], queueIds[4])
+		else
+			timestamper2 = ts:newUdpTimestamper(queueIds[3], queueIds[4])
+		end
 		hist2 = hist()
 	end
 	-- timestamping starts after and finishes before the main packet load starts/finishes

--- a/trafficgen.lua
+++ b/trafficgen.lua
@@ -996,7 +996,7 @@ function timerSlave(runTime, testParams, queueIds)
 		for count = 0, transactionsPerDirection - 1 do -- inner loop tests in one direction
 			rateLimit:wait()
 			counter = counter + 1
-			local lat = timestamper:measureLatency();
+			local lat = timestamper:measureLatency(testParams.frameSize);
 			if (lat) then
 				haveHisto = true;
                 		hist:update(lat)

--- a/trafficgen.lua
+++ b/trafficgen.lua
@@ -962,7 +962,7 @@ function timerSlave(runTime, testParams, queueIds)
 	local hist1, hist2, haveHisto1, haveHisto2, timestamper1, timestamper2
 	local transactionsPerDirection = 1 -- the number of transactions before switching direction
 	local frameSizeWithoutCrc = testParams.frameSize - 4
-	local rateLimit = timer:new(0.001) -- less than 100 samples per second
+	local rateLimit = timer:new(0.001) -- less than 1000 samples per second
 	local sampleLog1 = {}
 	local sampleLog2 = {}
 


### PR DESCRIPTION
Lots of latency related changes and a few generic items.  Specifically address issues #7 and #3.

- By default negative packet loss results in up to 3 retries before the attempted speed is marked as a failure.  This can be overriden to achieve the current behavior of accepting negative packet loss as success.

- Print the final report on every attempt but label it as RESULT instead of REPORT

- Log all latency samples for jitter analysis.

- Set latency packet size to requested packet size.  If size < 76 then UDP packets are no longer used for latency measurements.

- Dump the testParams after loading the config file for validation