### PR TITLE
Need this change to avoid 'Installation cannot run with T defined and…

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,7 +25,7 @@ if git submodule init && git submodule update; then
 
 		if pushd libmoon/deps/dpdk; then
 			sed -i -e 's@SRCS-y += ethtool/igb/igb_main.c@#SRCS-y += ethtool/igb/igb_main.c/@' lib/librte_eal/linuxapp/kni/Makefile
-			if make -j $NUM_CPUS install T=x86_64-native-linuxapp-gcc; then
+			if make -j $NUM_CPUS install T=x86_64-native-linuxapp-gcc DESTDIR=install; then
 				popd 
 			else
 				echo "make-install of dpdk failed, exiting"


### PR DESCRIPTION
… DESTDIR undefined' build error

Working on 'clean' VSPERF machines with 'sudo' level access only. dpdk build/installation fails because this env variable is not set.  See:

lua-trafficgen/MoonGen/libmoon/deps/dpdk/mk/rte.sdkinstall.mk

for error during 'make install'

Log snippet:

  CC main.o
  LD cmdline_test
  LD dpdk-procinfo
  LD testacl
  LD dpdk-pdump
  INSTALL-APP dpdk-procinfo
  INSTALL-MAP dpdk-procinfo.map
  INSTALL-APP cmdline_test
  INSTALL-MAP cmdline_test.map
  LD testpipeline
  INSTALL-APP testacl
  INSTALL-MAP testacl.map
  INSTALL-APP dpdk-pdump
  INSTALL-MAP dpdk-pdump.map
  INSTALL-MAP testpipeline.map
  INSTALL-APP testpipeline
Build complete [x86_64-native-linuxapp-gcc]
Installation cannot run with T defined and DESTDIR undefined
