### PR TITLE
trex-txrx.py: add ethernet frame overhead to IMIX packet sizes to get…

### DIFF
--- a/trex-txrx.py
+++ b/trex-txrx.py
@@ -26,8 +26,10 @@ def calculate_latency_pps (dividend, divisor, total_rate):
 def create_traffic_profile (direction, measure_latency, default_stream_pg_id_base, latency_stream_pg_id_base, latency_rate, frame_size, num_flows, src_mac_flows, dst_mac_flows, src_ip_flows, dst_ip_flows, mac_src, mac_dst, ip_src, ip_dst):
      streams = { 'default': { 'pg_ids': [], 'names': [], 'frame_sizes': [], 'traffic_shares': [] }, 'latency': { 'pg_ids': [], 'names': [], 'frame_sizes': [], 'traffic_shares': [] } }
 
+     ethernet_frame_overhead = 18
+
      if frame_size == "imix":
-          # imix is defined as 7 packets of size 40 bytes, 4 packets of size 576 bytes, and 1 packet of size 1500 bytes
+          # imix is defined as the following packets (including IP header): 7 of size 40 bytes, 4 of size 576 bytes, and 1 of size 1500 bytes
           # from https://en.wikipedia.org/wiki/Internet_Mix
 
           small_packets = 7
@@ -35,9 +37,9 @@ def create_traffic_profile (direction, measure_latency, default_stream_pg_id_bas
           large_packets = 1
           total_packets = small_packets + medium_packets + large_packets
 
-          small_packet_bytes = 40
-          medium_packet_bytes = 576
-          large_packet_bytes = 1500
+          small_packet_bytes = 40 + ethernet_frame_overhead
+          medium_packet_bytes = 576 + ethernet_frame_overhead
+          large_packet_bytes = 1500 + ethernet_frame_overhead
 
           small_stream_pg_id = default_stream_pg_id_base
           medium_stream_pg_id = default_stream_pg_id_base + 1


### PR DESCRIPTION
… correct frame size

Here are packet traces from VPP for each IMIX packet size:

```
40B:

00:52:29:876462: dpdk-input
  FortyGigabitEthernet81/0/0 rx queue 0
  buffer 0x122af: current data 0, length 60, free-list 0, totlen-nifb 0, trace 0x1
  PKT MBUF: port 0, nb_segs 1, pkt_len 60
    buf_len 2176, data_len 60, ol_flags 0x8, data_off 128, phys_addr 0xfb210ac0
    packet_type 0x291
    Packet Offload Flags
      PKT_RX_L4_CKSUM_BAD (0x0008) L4 cksum of RX pkt. is not OK
    Packet Types
      RTE_PTYPE_L2_ETHER (0x0001) Ethernet packet
      RTE_PTYPE_L3_IPV4_EXT_UNKNOWN (0x0090) IPv4 packet with or without extension headers
      RTE_PTYPE_L4_UDP (0x0200) UDP packet
  IP4: 68:00:00:00:2b:d0 -> 68:00:00:00:2b:f0
  UDP: 10.0.0.44 -> 8.0.0.44
    tos 0x01, ttl 64, length 40, checksum 0x696a
    fragment id 0xff02
  UDP: 53 -> 53
    length 20, checksum 0x1a88
00:52:29:876470: ethernet-input
  IP4: 68:00:00:00:2b:d0 -> 68:00:00:00:2b:f0
00:52:29:876480: l2-input
  l2-input: sw_if_index 1 dst 68:00:00:00:2b:f0 src 68:00:00:00:2b:d0
00:52:29:876480: l2-output
  l2-output: sw_if_index 2 dst 68:00:00:00:2b:f0 src 68:00:00:00:2b:d0
00:52:29:876480: FortyGigabitEthernet84/0/0-output
  FortyGigabitEthernet84/0/0
  IP4: 68:00:00:00:2b:d0 -> 68:00:00:00:2b:f0
  UDP: 10.0.0.44 -> 8.0.0.44
    tos 0x01, ttl 64, length 40, checksum 0x696a
    fragment id 0xff02
  UDP: 53 -> 53
    length 20, checksum 0x1a88
00:52:29:876481: FortyGigabitEthernet84/0/0-tx
  FortyGigabitEthernet84/0/0 tx queue 1
  buffer 0x122af: current data 0, length 60, free-list 0, totlen-nifb 0, trace 0x1
  IP4: 68:00:00:00:2b:d0 -> 68:00:00:00:2b:f0
  UDP: 10.0.0.44 -> 8.0.0.44
    tos 0x01, ttl 64, length 40, checksum 0x696a
    fragment id 0xff02
  UDP: 53 -> 53
    length 20, checksum 0x1a88
```

```
576B:

00:52:29:876462: dpdk-input
  FortyGigabitEthernet81/0/0 rx queue 0
  buffer 0x3b2fb: current data 0, length 590, free-list 0, totlen-nifb 0, trace 0x0
  PKT MBUF: port 0, nb_segs 1, pkt_len 590
    buf_len 2176, data_len 590, ol_flags 0x8, data_off 128, phys_addr 0xfbc51dc0
    packet_type 0x291
    Packet Offload Flags
      PKT_RX_L4_CKSUM_BAD (0x0008) L4 cksum of RX pkt. is not OK
    Packet Types
      RTE_PTYPE_L2_ETHER (0x0001) Ethernet packet
      RTE_PTYPE_L3_IPV4_EXT_UNKNOWN (0x0090) IPv4 packet with or without extension headers
      RTE_PTYPE_L4_UDP (0x0200) UDP packet
  IP4: 68:00:00:01:33:d0 -> 68:00:00:01:33:f0
  UDP: 10.0.1.52 -> 8.0.1.52
    tos 0x01, ttl 64, length 576, checksum 0x6543
    fragment id 0xff01
  UDP: 53 -> 53
    length 556, checksum 0xf839
00:52:29:876470: ethernet-input
  IP4: 68:00:00:01:33:d0 -> 68:00:00:01:33:f0
00:52:29:876480: l2-input
  l2-input: sw_if_index 1 dst 68:00:00:01:33:f0 src 68:00:00:01:33:d0
00:52:29:876480: l2-output
  l2-output: sw_if_index 2 dst 68:00:00:01:33:f0 src 68:00:00:01:33:d0
00:52:29:876480: FortyGigabitEthernet84/0/0-output
  FortyGigabitEthernet84/0/0
  IP4: 68:00:00:01:33:d0 -> 68:00:00:01:33:f0
  UDP: 10.0.1.52 -> 8.0.1.52
    tos 0x01, ttl 64, length 576, checksum 0x6543
    fragment id 0xff01
  UDP: 53 -> 53
    length 556, checksum 0xf839
00:52:29:876481: FortyGigabitEthernet84/0/0-tx
  FortyGigabitEthernet84/0/0 tx queue 1
  buffer 0x3b2fb: current data 0, length 590, free-list 0, totlen-nifb 0, trace 0x0
  IP4: 68:00:00:01:33:d0 -> 68:00:00:01:33:f0
  UDP: 10.0.1.52 -> 8.0.1.52
    tos 0x01, ttl 64, length 576, checksum 0x6543
    fragment id 0xff01
  UDP: 53 -> 53
    length 556, checksum 0xf839
```

```
1500B:

00:52:29:876490: dpdk-input
  FortyGigabitEthernet81/0/0 rx queue 0
  buffer 0x3b51d: current data 0, length 1514, free-list 0, totlen-nifb 0, trace 0x5
  PKT MBUF: port 0, nb_segs 1, pkt_len 1514
    buf_len 2176, data_len 1514, ol_flags 0x8, data_off 128, phys_addr 0xfbc5a640
    packet_type 0x291
    Packet Offload Flags
      PKT_RX_L4_CKSUM_BAD (0x0008) L4 cksum of RX pkt. is not OK
    Packet Types
      RTE_PTYPE_L2_ETHER (0x0001) Ethernet packet
      RTE_PTYPE_L3_IPV4_EXT_UNKNOWN (0x0090) IPv4 packet with or without extension headers
      RTE_PTYPE_L4_UDP (0x0200) UDP packet
  IP4: 68:00:00:02:46:d0 -> 68:00:00:02:46:f0
  UDP: 10.0.2.71 -> 8.0.2.71
    tos 0x01, ttl 64, length 1500, checksum 0x5f82
    fragment id 0xff00
  UDP: 53 -> 53
    length 1480, checksum 0x8798
00:52:29:876549: ethernet-input
  IP4: 68:00:00:02:46:d0 -> 68:00:00:02:46:f0
00:52:29:876702: l2-input
  l2-input: sw_if_index 1 dst 68:00:00:02:46:f0 src 68:00:00:02:46:d0
00:52:29:876704: l2-output
  l2-output: sw_if_index 2 dst 68:00:00:02:46:f0 src 68:00:00:02:46:d0
00:52:29:876706: FortyGigabitEthernet84/0/0-output
  FortyGigabitEthernet84/0/0
  IP4: 68:00:00:02:46:d0 -> 68:00:00:02:46:f0
  UDP: 10.0.2.71 -> 8.0.2.71
    tos 0x01, ttl 64, length 1500, checksum 0x5f82
    fragment id 0xff00
  UDP: 53 -> 53
    length 1480, checksum 0x8798
00:52:29:876710: FortyGigabitEthernet84/0/0-tx
  FortyGigabitEthernet84/0/0 tx queue 1
  buffer 0x3b51d: current data 0, length 1514, free-list 0, totlen-nifb 0, trace 0x5
  IP4: 68:00:00:02:46:d0 -> 68:00:00:02:46:f0
  UDP: 10.0.2.71 -> 8.0.2.71
    tos 0x01, ttl 64, length 1500, checksum 0x5f82
    fragment id 0xff00
  UDP: 53 -> 53
    length 1480, checksum 0x8798
```

