### PR TITLE
binary-search.py and trex-txrx.py: add revunidirec

### DIFF
--- a/binary-search.py
+++ b/binary-search.py
@@ -90,6 +90,12 @@ def process_options ():
                         default=1,
                         type = int,
                         )
+    parser.add_argument('--run-revunidirec',
+                        dest='run_revunidirec',
+                        help='0 = Tx on first device, 1 = Tx on second devices',
+                        default=0,
+                        type = int,
+                        )
     parser.add_argument('--validation-runtime', 
                         dest='validation_runtime',
                         help='tiral period in seconds during final validation',
@@ -239,7 +245,11 @@ def calculate_tx_pps_target(trial_params, streams, tmp_stats):
      if trial_params['rate_unit'] == "%":
           total_target_bytes = (tmp_stats['tx_available_bandwidth'] / bits_per_byte) * (trial_params['rate'] / 100)
      else:
-          total_target_bytes = (trial_params['frame_size'] + packet_overhead_bytes) * trial_params['rate'] * 1000000
+          if trial_params['frame_size'] < 64:
+               frame_size = 64
+          else:
+               frame_size = trial_params['frame_size']
+          total_target_bytes = (frame_size + packet_overhead_bytes) * trial_params['rate'] * 1000000
 
      for frame_size, traffic_shares in zip(streams['default']['frame_sizes'], streams['default']['traffic_shares']):
           default_packet_avg_bytes += (frame_size * traffic_shares)
@@ -279,7 +289,9 @@ def run_trial (trial_params):
     tmp_stats[1]['tx_available_bandwidth'] = 0.0
 
     cmd = ""
-    streams = []
+    streams = dict()
+    streams[0] = 0
+    streams[1] = 0
 
     if trial_params['traffic_generator'] == 'moongen-txrx':
         cmd = './MoonGen/build/MoonGen txrx.lua'
@@ -345,6 +357,7 @@ def run_trial (trial_params):
         cmd = cmd + ' --size=' + str(trial_params['frame_size'])
         cmd = cmd + ' --runtime=' + str(trial_params['runtime'])
         cmd = cmd + ' --run-bidirec=' + str(trial_params['run_bidirec'])
+        cmd = cmd + ' --run-revunidirec=' + str(trial_params['run_revunidirec'])
         cmd = cmd + ' --num-flows=' + str(trial_params['num_flows'])
         if trial_params['src_ips'] != '':
              cmd = cmd + ' --src-ips=' + str(trial_params['src_ips'])
@@ -389,19 +402,20 @@ def run_trial (trial_params):
                   if m:
                        results = json.loads(m.group(1))
 
-                       tmp_stats[0]['tx_available_bandwidth'] = results[0]['speed'] * 1000 * 1000 * 1000
+                       if not trial_params['run_revunidirec']:
+                            tmp_stats[0]['tx_available_bandwidth'] = results[0]['speed'] * 1000 * 1000 * 1000
 
-                       if trial_params['run_bidirec']:
+                       if trial_params['run_bidirec'] or trial_params['run_revunidirec']:
                             tmp_stats[1]['tx_available_bandwidth'] = results[1]['speed'] * 1000 * 1000 * 1000
                   #PARSABLE STREAMS FOR DIRECTION 'a': {"default": {"traffic_shares": [0.5833333333333334,0.3333333333333333,0.08333333333333333],"names": ["small_stream_a","medium_stream_a","large_stream_a"],"pg_ids": [128,129,130],"frame_sizes": [40,576,1500]},"latency": {"traffic_shares": [0.5833333333333334,0.3333333333333333,0.08333333333333333],"names": ["small_latency_stream_a","medium_latency_stream_a","large_latency_stream_a"],"pg_ids": [0,1,2],"frame_sizes": [40,576,1500]}}
                   m = re.search(r"PARSABLE STREAMS FOR DIRECTION '([ab])':\s+(.*)$", line)
                   if m:
                        if m.group(1) == "a":
-                            streams.insert(0, json.loads(m.group(2)))
+                            streams[0] = json.loads(m.group(2))
 
                             stats[0]['tx_pps_target'] = calculate_tx_pps_target(trial_params, streams[0], tmp_stats[0])
                        elif m.group(1) == "b":
-                            streams.insert(1, json.loads(m.group(2)))
+                            streams[1] = json.loads(m.group(2))
 
                             stats[1]['tx_pps_target'] = calculate_tx_pps_target(trial_params, streams[1], tmp_stats[1])
                   #PARSABLE RESULT: {"0":{"tx_util":37.68943472,"rx_bps":11472348160.0,"obytes":43064997504,"rx_pps":22406932.0,"ipackets":672312848,"oerrors":0,"rx_util":37.6436432,"opackets":672890586,"tx_pps":22434198.0,"tx_bps":11486302208.0,"ierrors":0,"rx_bps_L1":15057457280.0,"tx_bps_L1":15075773888.0,"ibytes":43028022272},"1":{"tx_util":37.6893712,"rx_bps":11486310400.0,"obytes":43063561984,"rx_pps":22434204.0,"ipackets":672890586,"oerrors":0,"rx_util":37.6894576,"opackets":672868156,"tx_pps":22434148.0,"tx_bps":11486284800.0,"ierrors":0,"rx_bps_L1":15075783040.0,"tx_bps_L1":15075748480.0,"ibytes":43064997504},"latency":{"global":{"bad_hdr":0,"old_flow":0}},"global":{"rx_bps":22958659584.0,"bw_per_core":7.34,"rx_cpu_util":0.0,"rx_pps":44841136.0,"queue_full":0,"cpu_util":62.6,"tx_pps":44868344.0,"tx_bps":22972585984.0,"rx_drop_bps":0.0},"total":{"tx_util":75.37880591999999,"rx_bps":22958658560.0,"obytes":86128559488,"ipackets":1345203434,"rx_pps":44841136.0,"rx_util":75.3331008,"oerrors":0,"opackets":1345758742,"tx_pps":44868346.0,"tx_bps":22972587008.0,"ierrors":0,"rx_bps_L1":30133240320.0,"tx_bps_L1":30151522368.0,"ibytes":86093019776},"flow_stats":{"1":{"rx_bps":{"0":"N/A","1":"N/A","total":"N/A"},"rx_pps":{"0":"N/A","1":20884464.286073223,"total":20884464.286073223},"rx_pkts":{"0":0,"1":672890586,"total":672890586},"rx_bytes":{"total":"N/A"},"tx_bytes":{"0":43064997504,"1":0,"total":43064997504},"tx_pps":{"0":20898314.26218906,"1":"N/A","total":20898314.26218906},"tx_bps":{"0":10699936902.240799,"1":"N/A","total":10699936902.240799},"tx_pkts":{"0":672890586,"1":0,"total":672890586},"rx_bps_L1":{"0":"N/A","1":"N/A","total":"N/A"},"tx_bps_L1":{"0":14043667184.191048,"1":"N/A","total":14043667184.191048}},"2":{"rx_bps":{"0":"N/A","1":"N/A","total":"N/A"},"rx_pps":{"0":20884967.481241994,"1":"N/A","total":20884967.481241994},"rx_pkts":{"0":672312848,"1":0,"total":672312848},"rx_bytes":{"total":"N/A"},"tx_bytes":{"0":0,"1":43063561984,"total":43063561984},"tx_pps":{"0":"N/A","1":20898728.6582104,"total":20898728.6582104},"tx_bps":{"0":"N/A","1":10700149073.003725,"total":10700149073.003725},"tx_pkts":{"0":0,"1":672868156,"total":672868156},"rx_bps_L1":{"0":"N/A","1":"N/A","total":"N/A"},"tx_bps_L1":{"0":"N/A","1":14043945658.317389,"total":14043945658.317389}},"global":{"rx_err":{},"tx_err":{}}}}
@@ -409,31 +423,32 @@ def run_trial (trial_params):
                   if m:
                        results = json.loads(m.group(1))
 
-                       for pg_id, frame_size in zip(streams[0]['default']['pg_ids'], streams[0]['default']['frame_sizes']):
-                            stats[0]['tx_packets'] += int(results["flow_stats"][str(pg_id)]["tx_pkts"]["total"])
-                            stats[1]['rx_packets'] += int(results["flow_stats"][str(pg_id)]["rx_pkts"]["total"])
-
-                            stats[0]['tx_bandwidth'] += int(results["flow_stats"][str(pg_id)]["tx_pkts"]["total"]) * (frame_size + tmp_stats[0]['packet_overhead_bytes'])
-                            stats[1]['rx_bandwidth'] += int(results["flow_stats"][str(pg_id)]["rx_pkts"]["total"]) * (frame_size + tmp_stats[0]['packet_overhead_bytes'])
-
-                       if trial_params['measure_latency']:
-                            for pg_id, frame_size in zip(streams[0]['latency']['pg_ids'], streams[0]['latency']['frame_sizes']):
+                       if not trial_params['run_revunidirec']:
+                            for pg_id, frame_size in zip(streams[0]['default']['pg_ids'], streams[0]['default']['frame_sizes']):
                                  stats[0]['tx_packets'] += int(results["flow_stats"][str(pg_id)]["tx_pkts"]["total"])
                                  stats[1]['rx_packets'] += int(results["flow_stats"][str(pg_id)]["rx_pkts"]["total"])
 
                                  stats[0]['tx_bandwidth'] += int(results["flow_stats"][str(pg_id)]["tx_pkts"]["total"]) * (frame_size + tmp_stats[0]['packet_overhead_bytes'])
                                  stats[1]['rx_bandwidth'] += int(results["flow_stats"][str(pg_id)]["rx_pkts"]["total"]) * (frame_size + tmp_stats[0]['packet_overhead_bytes'])
 
-                       stats[0]['tx_pps'] = float(stats[0]['tx_packets']) / float(trial_params['runtime'])
-                       stats[1]['rx_pps'] = float(stats[1]['rx_packets']) / float(trial_params['runtime'])
+                            if trial_params['measure_latency']:
+                                 for pg_id, frame_size in zip(streams[0]['latency']['pg_ids'], streams[0]['latency']['frame_sizes']):
+                                      stats[0]['tx_packets'] += int(results["flow_stats"][str(pg_id)]["tx_pkts"]["total"])
+                                      stats[1]['rx_packets'] += int(results["flow_stats"][str(pg_id)]["rx_pkts"]["total"])
 
-                       stats[0]['tx_bandwidth'] = float(stats[0]['tx_bandwidth']) / float(trial_params['runtime']) * tmp_stats[0]['bits_per_byte']
-                       stats[1]['rx_bandwidth'] = float(stats[1]['rx_bandwidth']) / float(trial_params['runtime']) * tmp_stats[0]['bits_per_byte']
+                                      stats[0]['tx_bandwidth'] += int(results["flow_stats"][str(pg_id)]["tx_pkts"]["total"]) * (frame_size + tmp_stats[0]['packet_overhead_bytes'])
+                                      stats[1]['rx_bandwidth'] += int(results["flow_stats"][str(pg_id)]["rx_pkts"]["total"]) * (frame_size + tmp_stats[0]['packet_overhead_bytes'])
 
-                       print('tx_packets, tx_rate, tx_bandwidth, device', stats[0]['tx_packets'], stats[0]['tx_pps'], stats[0]['tx_bandwidth'], 0)
-                       print('rx_packets, rx_rate, rx_bandwidth, device', stats[1]['rx_packets'], stats[1]['rx_pps'], stats[1]['rx_bandwidth'], 1)
+                            stats[0]['tx_pps'] = float(stats[0]['tx_packets']) / float(trial_params['runtime'])
+                            stats[1]['rx_pps'] = float(stats[1]['rx_packets']) / float(trial_params['runtime'])
 
-                       if trial_params['run_bidirec']:
+                            stats[0]['tx_bandwidth'] = float(stats[0]['tx_bandwidth']) / float(trial_params['runtime']) * tmp_stats[0]['bits_per_byte']
+                            stats[1]['rx_bandwidth'] = float(stats[1]['rx_bandwidth']) / float(trial_params['runtime']) * tmp_stats[0]['bits_per_byte']
+
+                            print('tx_packets, tx_rate, tx_bandwidth, device', stats[0]['tx_packets'], stats[0]['tx_pps'], stats[0]['tx_bandwidth'], 0)
+                            print('rx_packets, rx_rate, rx_bandwidth, device', stats[1]['rx_packets'], stats[1]['rx_pps'], stats[1]['rx_bandwidth'], 1)
+
+                       if trial_params['run_bidirec'] or trial_params['run_revunidirec']:
                             for pg_id, frame_size in zip(streams[1]['default']['pg_ids'], streams[1]['default']['frame_sizes']):
                                  stats[1]['tx_packets'] += int(results["flow_stats"][str(pg_id)]["tx_pkts"]["total"])
                                  stats[0]['rx_packets'] += int(results["flow_stats"][str(pg_id)]["rx_pkts"]["total"])
@@ -517,6 +532,7 @@ def main():
     print("validation-runtime", t_global.args.validation_runtime)
     print("sniff-runtime", t_global.args.sniff_runtime)
     print("run-bidirec", t_global.args.run_bidirec)
+    print("run-revunidirec", t_global.args.run_revunidirec)
     print("use-num-flows", t_global.args.num_flows)
     print("use-src-mac-flows", t_global.args.use_src_mac_flows)
     print("use-dst-mac-flows", t_global.args.use_dst_mac_flows)
@@ -543,6 +559,7 @@ def main():
     trial_params['rate_tolerance'] = t_global.args.rate_tolerance
     trial_params['frame_size'] = t_global.args.frame_size
     trial_params['run_bidirec'] = t_global.args.run_bidirec
+    trial_params['run_revunidirec'] = t_global.args.run_revunidirec
     trial_params['num_flows'] = t_global.args.num_flows
     trial_params['use_src_mac_flows']= t_global.args.use_src_mac_flows
     trial_params['use_dst_mac_flows']= t_global.args.use_dst_mac_flows
@@ -566,9 +583,13 @@ def main():
     trial_params['max_retries'] = t_global.args.max_retries
     trial_params['search_granularity'] = t_global.args.search_granularity
 
-    test_dev_pairs = [ { 'tx': 0, 'rx': 1 } ]
-    if trial_params['run_bidirec']:
-         test_dev_pairs.append({ 'tx': 1, 'rx': 0 })
+    if trial_params['run_revunidirec']:
+         test_dev_pairs = [ { 'tx': 1, 'rx': 0 } ]
+    else:
+         test_dev_pairs = [ { 'tx': 0, 'rx': 1 } ]
+
+         if trial_params['run_bidirec']:
+              test_dev_pairs.append({ 'tx': 1, 'rx': 0 })
 
     perform_sniffs = False
     do_sniff = False


### PR DESCRIPTION
- The new revunidirec traffic direction allows a unidirectional test
  to be run in the opposite direction of the existing unidirec test
  scenario.