### PR TITLE
binary-search.py: exit with results=0 when search falls below minimum…

### DIFF
--- a/binary-search.py
+++ b/binary-search.py
@@ -1240,7 +1240,23 @@ def main():
                    rate = minimum_rate
               elif (rate == minimum_rate or prev_rate <= minimum_rate) and trial_result == 'fail':
                    print("Binary search ended up at rate which is below minimum allowed")
-                   quit(1)
+                   print("There is no trial which passed")
+                   failed_stats = []
+                   failed_stats.append({ 'rx_bandwidth':  0.0,
+                                         'rx_packets':    0,
+                                         'rx_pps':        0.0,
+                                         'tx_bandwidth':  0.0,
+                                         'tx_packets':    0,
+                                         'tx_pps':        0.0,
+                                         'tx_pps_target': 0.0 })
+                   failed_stats.append(copy.deepcopy(failed_stats[0]))
+                   print("RESULT:")
+                   print('[')
+                   print(json.dumps(failed_stats[0], indent = 4, separators=(',', ': '), sort_keys = True))
+                   print(',')
+                   print(json.dumps(failed_stats[1], indent = 4, separators=(',', ': '), sort_keys = True))
+                   print(']')
+                   return(0)
 
               if t_global.args.trial_gap:
                    print("Sleeping for %d seconds between trial attempts" % t_global.args.trial_gap)


### PR DESCRIPTION
… rate

- If the binary search falls below the minimum rate, exit with results
  (throughput, packets, etc.) equal to 0 rather than bailing out with
  an error.

- This allows pbench-trafficgen to continue executing additional
  iterations rather than quiting, which is now reserved for more
  serious problems (ie. no packets transmitted, packets received on
  the wrong port, etc.) rather than for configurations which simply
  underperform.

- It also ensures that results calculated with pbench-trafficgen more
  appropriately account for this result by including it in the average
  calcuations (previously the result would have been ignored if the
  test did not exit).