### PR TITLE
binary-search.py: always pass the --max-loss-pct value to trex-txrx.py

### DIFF
--- a/binary-search.py
+++ b/binary-search.py
@@ -590,8 +590,8 @@ def run_trial (trial_params, port_info, stream_info, detailed_stats):
         cmd = cmd + ' --use-protocol-flows=' + str(trial_params['use_protocol_flows'])
         cmd = cmd + ' --packet-protocol=' + str(trial_params['packet_protocol'])
         cmd = cmd + ' --stream-mode=' + trial_params['stream_mode']
+        cmd = cmd + ' --max-loss-pct=' + str(trial_params['max_loss_pct'])
         if trial_params['stream_mode'] == "segmented" and trial_params['enable_segment_monitor']:
-             cmd = cmd + ' --max-loss-pct=' + str(trial_params['max_loss_pct'])
              cmd = cmd + ' --enable-segment-monitor'
         if trial_params['use_device_stats']:
              cmd = cmd + ' --skip-hw-flow-stats'


### PR DESCRIPTION
-- This ensures that the logging that trex-txrx.py provides is
   consistent with the test being run.  Without this change
   trex-txrx.py would log it's default value for --max-loss-pct which
   might not agree with the search that is being run by
   binary-search.py.  This could happen when a non-default
   --max-loss-pct value was specified to binary-search.py and the test
   was not using segmented streams with the segment stream monitor.